### PR TITLE
move mocha & standard to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,11 @@
   },
   "homepage": "https://github.com/rdfjs/sink-map",
   "dependencies": {
+  },
+  "devDependencies": {
     "mocha": "^5.2.0",
     "standard": "^12.0.1"
   },
-  "devDependencies": {},
   "engines": {
     "node": ">=6"
   }


### PR DESCRIPTION
Those dependencies are only needed for development and should not be installed when using sink-map as a package.