### PR TITLE
feat: extend sink map to handle sink factory method

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,27 @@
+import { PassThrough } from 'readable-stream'
+
 class SinkMap extends Map {
   import (key, input, options) {
-    const parser = this.get(key)
+    const sink = this.get(key)
 
-    if (!parser) {
+    if (!sink) {
       return null
     }
 
-    return parser.import(input, options)
+    if (typeof parser === 'function') {
+      const passThrough = new PassThrough()
+      Promise.resolve().then(async () => {
+        const sinkInstance = await sink()
+        this.set(key, sinkInstance)
+
+        sinkInstance.import(input, options).pipe(passThrough)
+      })
+
+      return passThrough
+    }
+
+    return sink.import(input, options)
   }
 }
 
-module.exports = SinkMap
+export { SinkMap }

--- a/main.js
+++ b/main.js
@@ -1,0 +1,3 @@
+// eslint-disable-next-line no-global-assign
+require = require('esm')(module)
+module.exports = require('./index.js')

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "@rdfjs/sink-map",
   "version": "1.0.1",
   "description": "Map for RDFJS Sinks including shortcut methods",
-  "main": "index.js",
+  "main": "main.js",
+  "module": "index.js",
   "scripts": {
     "test": "standard && mocha"
   },
@@ -22,7 +23,10 @@
     "url": "https://github.com/rdfjs-base/sink-map/issues"
   },
   "homepage": "https://github.com/rdfjs-base/sink-map",
-  "dependencies": {},
+  "dependencies": {
+    "esm": "^3.2.25",
+    "readable-stream": "^3.6.0"
+  },
   "devDependencies": {
     "mocha": "^5.2.0",
     "standard": "^12.0.1"


### PR DESCRIPTION
Extends the sink map to accept a Sink instance as well a lazy factory method so that dynamic importing is possible

```js
// this is a breaking change, as the export is now an ES module
// in node would be
// const { SinkMap } = require('@rdfjs/sink-map')
import { SinkMap } from '@rdfjs/sink-map'

const parsers = new SinkMap()

parsers.set('application/ld+json', async () => {
  const JsonLdParser = await import('@rdfjs/parser-jsonld')
  return new JsonLdParser()
})
```

Above is how I populate the map in [`@rdfjs/formats-common`](https://github.com/tpluscode/formats-common/tree/lazy-sink)

The parser module will only be loaded when `sink.import('application/ld+json', stream)` for the first time